### PR TITLE
Next page link header guard

### DIFF
--- a/src/main/java/com/talanlabs/gitlab/api/http/PagedImpl.java
+++ b/src/main/java/com/talanlabs/gitlab/api/http/PagedImpl.java
@@ -124,7 +124,7 @@ public class PagedImpl<T> implements Paged<T> {
 
     @Override
     public Paged<T> nextPage() throws IOException {
-        if (nextPageUrl == null) {
+        if (nextPageUrl == null || results.isEmpty()) {
             return null;
         }
         return gitLabAPI.retrieve().toPaged(gitLabAPI.removeAPIUrl(nextPageUrl), type);


### PR DESCRIPTION
Something changed recently in GitLab's API that is causing the `next` page link header to appear when there isn't another page.  This resulted in an infinite loop in the [sonar-gitlab-plugin](https://github.com/gabrie-allaigre/sonar-gitlab-plugin/blob/9b526100e382fbbb86ac55cb8ccfa910b33b4877/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabApiV3Wrapper.java#L124).

My hope is this is a clean fix that would apply to both `GitLabApiV3Wrapper` and `GitLabApiV4Wrapper`.  I would be happy to address any feedback you may have!